### PR TITLE
Implement signout and protect frontend routes

### DIFF
--- a/client/actions/constants.js
+++ b/client/actions/constants.js
@@ -7,3 +7,4 @@ export const JOIN_EVENT = 'JOIN_EVENT';
 export const SIGN_IN_SUCCESS = 'SIGN_IN_SUCCESS';
 export const SIGN_IN = 'SIGN_IN';
 export const SIGN_OUT = 'SIGN_OUT';
+export const SET_REDIRECT_URL = 'SET_REDIRECT_URL';

--- a/client/actions/userActions.js
+++ b/client/actions/userActions.js
@@ -16,6 +16,12 @@ export function setRedirectUrl(url){
   };
 }
 
+export function signOut(){
+  return {
+    type: constants.SIGN_OUT
+  };
+}
+
 export function signIn(id_token){
   return (dispatch) => {
     return axios.post('/api/v1/auth/login/', {'ID_Token': id_token})

--- a/client/actions/userActions.js
+++ b/client/actions/userActions.js
@@ -9,6 +9,13 @@ export function login(response, type){
   };
 }
 
+export function setRedirectUrl(url){
+  return {
+    type: constants.SET_REDIRECT_URL,
+    url
+  };
+}
+
 export function signIn(id_token){
   return (dispatch) => {
     return axios.post('/api/v1/auth/login/', {'ID_Token': id_token})

--- a/client/actions/userActions.js
+++ b/client/actions/userActions.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import * as constants from './constants';
-import {authenticationFailed, handleError, throwError} from '../utils/errorHandler';
+import { SET_REDIRECT_URL, SIGN_OUT, SIGN_IN } from './constants';
+import { authenticationFailed } from '../utils/errorHandler';
 
 export function login(response, type){
   return {
@@ -11,14 +11,14 @@ export function login(response, type){
 
 export function setRedirectUrl(url){
   return {
-    type: constants.SET_REDIRECT_URL,
+    type: SET_REDIRECT_URL,
     url
   };
 }
 
 export function signOut(){
   return {
-    type: constants.SIGN_OUT
+    type: SIGN_OUT
   };
 }
 
@@ -26,7 +26,7 @@ export function signIn(id_token){
   return (dispatch) => {
     return axios.post('/api/v1/auth/login/', {'ID_Token': id_token})
       .then((res) => {
-        dispatch(login(res, constants.SIGN_IN));
+        dispatch(login(res, SIGN_IN));
       })
       .catch(error => authenticationFailed(error));
   };

--- a/client/assets/style.scss
+++ b/client/assets/style.scss
@@ -7,7 +7,6 @@
 @import url('https://fonts.googleapis.com/css?family=Spectral+SC');
 @import url('https://fonts.googleapis.com/css?family=Ubuntu');
 
-/* MY STYLES */
 body {
   font-family: 'Lato', sans-serif;
 }
@@ -91,8 +90,6 @@ body {
     border: 0;
     font-size: 20px;
 }
-.event-list {
-}
 .event-list-header {
     display: flex;
     justify-content: space-between;
@@ -131,4 +128,15 @@ body {
     border: 0;
     font-size: 14px;
     text-transform: uppercase;
+}
+
+.not-found {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  p {
+    font-size: 80px;
+    color: #030303;
+  }
 }

--- a/client/components/App.js
+++ b/client/components/App.js
@@ -1,12 +1,34 @@
 import React, { Component } from 'react';
+import {connect} from 'react-redux';
+import {browserHistory} from 'react-router';
 
 // components
 import Header from './common/Header';
 import Footer from './common/Footer';
 
+// stylesheet
 import '../assets/style.scss';
 
 class App extends Component {
+
+  componentDidMount(){
+    if (this.props.currentUrl === "/" && this.props.isAuthenticated) {
+      browserHistory.replace("/home");
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { redirectUrl } = this.props;
+    const isLoggingOut = prevProps.isAuthenticated && !this.props.isAuthenticated;
+    const isLoggingIn = !prevProps.isAuthenticated && this.props.isAuthenticated;
+
+    if (isLoggingIn) {
+      redirectUrl ? browserHistory.replace(redirectUrl) : browserHistory.replace("/home");
+    } else if (isLoggingOut) {
+      browserHistory.replace("/");
+    }
+  }
+
   render() {
     return (
       <div className="wrapper">
@@ -18,4 +40,12 @@ class App extends Component {
   }
 }
 
-export default App;
+function mapStateToProps(state, ownProps) {
+  return {
+    isAuthenticated: state.access.isAuthenticated,
+    redirectUrl: state.url,
+    currentUrl: ownProps.location.pathname
+  }
+}
+
+export default connect(mapStateToProps)(App);

--- a/client/components/App.js
+++ b/client/components/App.js
@@ -32,7 +32,7 @@ class App extends Component {
   render() {
     return (
       <div className="wrapper">
-        {this.props.location.pathname === '/' ? null : <Header />}
+        {this.props.location.pathname !== '/' && <Header />}
         {this.props.children}
         <Footer />
       </div>

--- a/client/components/App.js
+++ b/client/components/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import {connect} from 'react-redux';
-import {browserHistory} from 'react-router';
+import { connect } from 'react-redux';
+import { browserHistory } from 'react-router';
 
 // components
 import Header from './common/Header';

--- a/client/components/HomePage/HomePage.js
+++ b/client/components/HomePage/HomePage.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 
 // components
 import Jumbotron from '../common/jumbotron';
@@ -10,7 +9,6 @@ class HomePage extends Component {
     return (
       <div className="homepage">
         <Jumbotron />
-        {this.props.children}
       </div>
     );
   }

--- a/client/components/HomePage/LoginPage.js
+++ b/client/components/HomePage/LoginPage.js
@@ -1,16 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { browserHistory } from 'react-router';
 
 require('dotenv').config();
 
-// images
-import signin_btn from '../../assets/img/btn_google_signin.png';
-import andela_logo from '../../assets/img/andela_logo.jpg';
-
 // actions
 import { signIn } from '../../actions/userActions';
-import {authenticationFailed, handleError} from "../../utils/errorHandler";
 
 
 class LoginPage extends Component {

--- a/client/components/HomePage/LoginPage.js
+++ b/client/components/HomePage/LoginPage.js
@@ -35,15 +35,14 @@ class LoginPage extends Component {
   }
 
   onSignIn() {
-    gapi.auth2.getAuthInstance().signIn()
-      .then((googleUser) => {
-        let id_token = googleUser.getAuthResponse().id_token;
-        this.props.signIn(id_token)
-          .then(() => {
-            browserHistory.push('/home');
-          })
-          .catch((error) => authenticationFailed(error))
-      });
+    let googleAuth = gapi.auth2.getAuthInstance();
+    if (googleAuth) {
+      googleAuth.signIn()
+        .then((googleUser) => {
+          let id_token = googleUser.getAuthResponse().id_token;
+          this.props.signIn(id_token)
+        });
+    }
   }
 
   render() {

--- a/client/components/HomePage/LoginPage.js
+++ b/client/components/HomePage/LoginPage.js
@@ -46,7 +46,6 @@ class LoginPage extends Component {
   }
 
   render() {
-    console.log(this.props.location.pathname);
     return (
       <div className="auth-page">
         <img className="andela" src="http://res.cloudinary.com/proton/image/upload/v1510947117/Condensed-white_qudkxm.png" />

--- a/client/components/SocialClub/SocialClubPage.js
+++ b/client/components/SocialClub/SocialClubPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import toastr from 'toastr';
 
 // actions
 import { getClub, joinClub } from '../../actions/socialClubActions';
@@ -9,7 +9,7 @@ import { sendEvent } from '../../actions/createEventActions';
 // components
 import PageHeader from './PageHeader';
 import EventList from '../Events/EventList';
-import toastr from 'toastr';
+
 
 
 const attendees = [

--- a/client/components/SocialClub/SocialClubPage.js
+++ b/client/components/SocialClub/SocialClubPage.js
@@ -244,7 +244,6 @@ class SocialClubPage extends Component {
 }
 
 function mapStateToProps(state, ownProps) {
-  console.log('State', state)
   return {
     club: state.socialClub
   };

--- a/client/components/common/EnsureLoggedIn.js
+++ b/client/components/common/EnsureLoggedIn.js
@@ -1,0 +1,35 @@
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {browserHistory} from 'react-router';
+
+import {setRedirectUrl} from "../../actions/userActions";
+
+
+class EnsureLoggedIn extends Component {
+
+  componentDidMount() {
+    const { dispatch, currentUrl, isAuthenticated } = this.props;
+
+    if (!isAuthenticated) {
+      dispatch(setRedirectUrl(currentUrl));
+      browserHistory.replace("/");
+    }
+  }
+
+  render() {
+    if (this.props.isAuthenticated) {
+      return this.props.children
+    } else {
+      return null
+    }
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    isAuthenticated: state.access.isAuthenticated,
+    currentUrl: ownProps.location.pathname
+  }
+}
+
+export default connect(mapStateToProps)(EnsureLoggedIn);

--- a/client/components/common/EnsureLoggedIn.js
+++ b/client/components/common/EnsureLoggedIn.js
@@ -1,8 +1,9 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
-import {browserHistory} from 'react-router';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { browserHistory } from 'react-router';
+import toastr from 'toastr';
 
-import {setRedirectUrl} from "../../actions/userActions";
+import { setRedirectUrl } from "../../actions/userActions";
 
 
 class EnsureLoggedIn extends Component {
@@ -13,6 +14,7 @@ class EnsureLoggedIn extends Component {
     if (!isAuthenticated) {
       setRedirectUrl(currentUrl);
       browserHistory.replace("/");
+      toastr.warning('Please sign in to continue');
     }
   }
 

--- a/client/components/common/EnsureLoggedIn.js
+++ b/client/components/common/EnsureLoggedIn.js
@@ -8,10 +8,10 @@ import {setRedirectUrl} from "../../actions/userActions";
 class EnsureLoggedIn extends Component {
 
   componentDidMount() {
-    const { dispatch, currentUrl, isAuthenticated } = this.props;
+    const { setRedirectUrl, currentUrl, isAuthenticated } = this.props;
 
     if (!isAuthenticated) {
-      dispatch(setRedirectUrl(currentUrl));
+      setRedirectUrl(currentUrl);
       browserHistory.replace("/");
     }
   }
@@ -32,4 +32,4 @@ function mapStateToProps(state, ownProps) {
   }
 }
 
-export default connect(mapStateToProps)(EnsureLoggedIn);
+export default connect(mapStateToProps, { setRedirectUrl })(EnsureLoggedIn);

--- a/client/components/common/Header.js
+++ b/client/components/common/Header.js
@@ -2,14 +2,25 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
+import {signOut} from "../../actions/userActions";
+
 class Header extends Component {
+  constructor(props){
+    super(props);
+    this.onSignOut = this.onSignOut.bind(this);
+  }
+
+  onSignOut(){
+    this.props.signOut();
+  }
+
   render() {
     return (
       <div>
         <nav className="navbar navbar-default navbar-fixed-top nav-menu no-margin no-padding">
           <div className="container-fluid">
             <div className="navbar-header">
-              <button type="button" className="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+              <button type="button" className="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-bar" aria-expanded="false" aria-controls="navbar">
                 <span className="sr-only">Toggle navigation</span>
                 <span className="icon-bar"></span>
                 <span className="icon-bar"></span>
@@ -17,17 +28,20 @@ class Header extends Component {
               </button>
               <Link to="/home" className="navbar-brand">Andela Socials</Link>
             </div>
+
+            <div className="collapse navbar-collapse" id="nav-bar">
+              <ul className="nav navbar-nav navbar-right">
+                <li>
+                  <a href="#" onClick={this.onSignOut}>Logout</a>
+                </li>
+              </ul>
+            </div>
+
           </div>
         </nav>
       </div>
-    )
+    );
   }
 }
 
-function mapStateToProps(state, ownProps) {
-  return {
-    number: state
-  };
-}
-
-export default connect(mapStateToProps)(Header);
+export default connect(null, { signOut })(Header);

--- a/client/components/common/Header.js
+++ b/client/components/common/Header.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
-import {signOut} from "../../actions/userActions";
+import { signOut } from "../../actions/userActions";
 
 class Header extends Component {
   constructor(props){

--- a/client/components/common/NotFound.js
+++ b/client/components/common/NotFound.js
@@ -1,0 +1,13 @@
+import React, {Component} from 'react';
+
+class NotFound extends Component {
+  render(){
+    return (
+      <div className="auth-page not-found">
+        <p>404</p>
+      </div>
+    );
+  }
+}
+
+export default NotFound;

--- a/client/components/common/NotFound.js
+++ b/client/components/common/NotFound.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 class NotFound extends Component {
   render(){
     return (
-      <div className="auth-page not-found">
+      <div className="not-found">
         <p>404</p>
       </div>
     );

--- a/client/middleware/auth.js
+++ b/client/middleware/auth.js
@@ -14,6 +14,9 @@ export const saveTokenMiddleware = ({getState, dispatch}) => next => action => {
       user: action.response.data.user,
     };
     dispatch(nextAction);
+  } else if (action.type === constants.SIGN_OUT){
+    localStorage.removeItem('a_socials');
+    delete axios.defaults.headers.common['Authorization'];
   }
 
   next(action);

--- a/client/middleware/auth.js
+++ b/client/middleware/auth.js
@@ -1,8 +1,8 @@
-import * as constants from '../actions/constants';
+import { SIGN_IN, SIGN_IN_SUCCESS, SIGN_OUT } from '../actions/constants';
 import axios from 'axios';
 
 export const saveTokenMiddleware = ({getState, dispatch}) => next => action => {
-  if (action.type === constants.SIGN_IN){
+  if (action.type === SIGN_IN){
     const token = action.response.data.token;
     axios.defaults.headers.common['Authorization'] = `JWT ${token}`;
     const jwtToSave = JSON.stringify({
@@ -10,11 +10,11 @@ export const saveTokenMiddleware = ({getState, dispatch}) => next => action => {
     });
     localStorage.setItem('a_socials', jwtToSave);
     let nextAction = {
-      type: constants.SIGN_IN_SUCCESS,
+      type: SIGN_IN_SUCCESS,
       user: action.response.data.user,
     };
     dispatch(nextAction);
-  } else if (action.type === constants.SIGN_OUT){
+  } else if (action.type === SIGN_OUT){
     localStorage.removeItem('a_socials');
     delete axios.defaults.headers.common['Authorization'];
   }

--- a/client/reducers/accessReducers.js
+++ b/client/reducers/accessReducers.js
@@ -1,4 +1,4 @@
-import * as constants from '../actions/constants';
+import { SIGN_IN_SUCCESS, SIGN_OUT } from '../actions/constants';
 import initialState from './initialState';
 
 /**
@@ -9,12 +9,12 @@ import initialState from './initialState';
  */
 function access(state = initialState.access, action) {
   switch (action.type) {
-    case constants.SIGN_IN_SUCCESS:
+    case SIGN_IN_SUCCESS:
       return {
         isAuthenticated: true,
         user: action.user
       };
-    case constants.SIGN_OUT:
+    case SIGN_OUT:
       return initialState.access;
     default:
       return state;

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -1,17 +1,15 @@
 import { socialClub, socialClubs } from './socialClubReducers';
-import { event} from './eventReducers';
-// import { users, user} from './userReducers';
+import { event } from './eventReducers';
 import access from './accessReducers';
+import url from './urlReducers';
 
 
 const rootReducer = {
   access,
   socialClubs,
   socialClub,
-  // events,
-  event
-  // users,
-  // user
+  event,
+  url,
 };
 
 export default rootReducer;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -2,8 +2,6 @@ export default {
   access: { isAuthenticated: false, user: {} },
   socialClubs: [],
   socialClub: {},
-  // events: [],
   event: {},
-  // users: [],
-  // user: {}
+  redirectUrl: ''
 };

--- a/client/reducers/socialClubReducers.js
+++ b/client/reducers/socialClubReducers.js
@@ -1,4 +1,4 @@
-import * as constants from '../actions/constants';
+import { GET_CLUBS, GET_CLUB, SIGN_OUT } from '../actions/constants';
 import initialState from './initialState';
 
 /**
@@ -9,9 +9,9 @@ import initialState from './initialState';
  */
 export function socialClubs(state = initialState.socialClubs, action) {
   switch(action.type){
-    case constants.GET_CLUBS:
+    case GET_CLUBS:
       return action.clubs;
-    case constants.SIGN_OUT:
+    case SIGN_OUT:
       return initialState.socialClubs;
     default:
       return state;
@@ -26,7 +26,7 @@ export function socialClubs(state = initialState.socialClubs, action) {
  */
 export function socialClub(state = initialState.socialClub, action) {
   switch(action.type){
-    case constants.GET_CLUB:
+    case GET_CLUB:
       return action.club;
     default:
       return state;

--- a/client/reducers/socialClubReducers.js
+++ b/client/reducers/socialClubReducers.js
@@ -8,10 +8,14 @@ import initialState from './initialState';
  * @returns {array} new state of socialClubs
  */
 export function socialClubs(state = initialState.socialClubs, action) {
-  if (action.type == constants.GET_CLUBS) {
-    return action.clubs || state;
+  switch(action.type){
+    case constants.GET_CLUBS:
+      return action.clubs;
+    case constants.SIGN_OUT:
+      return initialState.socialClubs;
+    default:
+      return state;
   }
-  return state;
 }
 
 /**

--- a/client/reducers/urlReducers.js
+++ b/client/reducers/urlReducers.js
@@ -1,0 +1,19 @@
+import * as constants from '../actions/constants';
+import initialState from './initialState';
+
+/**
+ * Reducer for setting redirectUrl
+ * @param {string} [state=initialState.access]
+ * @param {object} action
+ * @returns {object} redirectUrl state
+ */
+function url(state = initialState.redirectUrl, action) {
+  switch (action.type) {
+    case constants.SET_REDIRECT_URL:
+      return action.url;
+    default:
+      return state;
+  }
+}
+
+export default url;

--- a/client/reducers/urlReducers.js
+++ b/client/reducers/urlReducers.js
@@ -1,4 +1,4 @@
-import * as constants from '../actions/constants';
+import { SET_REDIRECT_URL } from '../actions/constants';
 import initialState from './initialState';
 
 /**
@@ -9,7 +9,7 @@ import initialState from './initialState';
  */
 function url(state = initialState.redirectUrl, action) {
   switch (action.type) {
-    case constants.SET_REDIRECT_URL:
+    case SET_REDIRECT_URL:
       return action.url;
     default:
       return state;

--- a/client/routes.js
+++ b/client/routes.js
@@ -7,11 +7,19 @@ import LoginPage from './components/HomePage/LoginPage';
 import HomePage from './components/HomePage/HomePage';
 import EventPage from './components/Events/index';
 import SocialClubPage from './components/SocialClub/SocialClubPage';
+import EnsureLoggedIn from "./components/common/EnsureLoggedIn";
+import NotFound from "./components/common/NotFound";
+
 
 export default
   <Route path="/" component={App}>
     <IndexRoute component={LoginPage} />
-  	<Route path="/home" component={HomePage} />
-  	<Route path="/clubs/:id" component={SocialClubPage} />
-    <Route path="/clubs/:club_id/events/:id" component={EventPage} />
+
+    <Route component={EnsureLoggedIn}>
+      <Route path="/home" component={HomePage} />
+      <Route path="/clubs/:id" component={SocialClubPage} />
+      <Route path="/clubs/:club_id/events/:id" component={EventPage} />
+    </Route>
+
+    <Route path="*" component={NotFound} />
   </Route>;


### PR DESCRIPTION
#### What Does This PR Do?
This PR enables users to sign out of the application and have all details about their session deleted from the browser. It also protects the routes so that unauthenticated users cannot visit any page asides from the login page and authenticated users cannot see the login page. A 404 Page is displayed when the url visited doesn't match any routes.

#### Description Of Task To Be Completed
Protect Frontend Routes, Sign out user

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
Pull this branch, start the application and visit localhost:8000

#### Screenshot(s)
N/A

#### What are the relevant github issues?
